### PR TITLE
Issue #30 Bug: Order Time does not format time correctly, fix(view-orders) zero pad minutes and seconds

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -26,6 +26,25 @@ class ViewOrders extends Component {
                 <div className="container-fluid">
                     {this.state.orders.map(order => {
                         const createdDate = new Date(order.createdAt);
+                        const dateFormatter = new Intl.DateTimeFormat('en-US', {
+                            hour: 'numeric',
+                            minute: 'numeric',
+                            second: 'numeric',
+                        })
+                        const formattedDate = dateFormatter.formatToParts(createdDate);
+                        const timeElements = {
+                            hours: '',
+                            minutes: '',
+                            seconds: ''
+                        }
+                        for (const element of formattedDate) {
+                            let {type, value}  = element; 
+                            type = `${type}s`;
+                            if (timeElements.hasOwnProperty(type)) {
+                                timeElements[type] = value;
+                            } 
+                        }
+                        const {hours, minutes, seconds} = timeElements;
                         return (
                             <div className="row view-order-container" key={order._id}>
                                 <div className="col-md-4 view-order-left-col p-3">
@@ -33,7 +52,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {`${hours}:${minutes}:${seconds}`}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
Resolves issue #30 Now minutes and seconds are displayed with a 0 at the start when the order is made less than 10 minutes into the hour or less than 10 seconds into the minute.