### PR TITLE
fix :  Order form submit doesn't work #14

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
matched the state for menuItemChosen when customer selects a food item from items to order_item as it is set in the state.