### PR TITLE
fix(docker): fixed volume path for Ubuntu Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - server
     volumes:
     - ./application:/home/node/application
-    - home/node/application/node_modules
+    - /home/node/application/node_modules
 
   server:
     build: './server'
@@ -23,7 +23,7 @@ services:
     - database
     volumes:
     - ./server:/home/node/server
-    - home/node/server/node_modules
+    - /home/node/server/node_modules
   database:
     image: "mongo"
     networks:


### PR DESCRIPTION
`docker-compose up` was failing on Ubuntu 18.04 due to non-absolute volume path for the node_modules folder: `home/node/application/node_modules`

Note: need to verify this change doesn't effect Windows or Mac environments. In theory it shouldn't.

closes #58 