### PR TITLE
docs(readme): improve installation instructions; add Linux link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ This is a multi-container docker environment that utilizes Docker to create thre
 ## Project Requirements
 
 - Docker
-    - [For Mac Users](https://docs.docker.com/docker-for-mac/install/)
-    - [For Windows 10 Pro/Enterprise Users](https://docs.docker.com/docker-for-windows/install/)
-    - [For Windows 7 or Windows 10 home Users](https://docs.docker.com/toolbox/toolbox_install_windows/)
-    - Kitematic should come automatically installed, with Docker, but make sure you have it available, it will be very useful in managine containers
+    - For Mac Users: [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/)
+    - For Windows 10 Pro/Enterprise Users: [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)
+    - For Windows 7 or Windows 10 home Users: [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/)
+    - For Linux Users (follow link and choose your Distro): [Docker Engine](https://docs.docker.com/engine/install/)
 - Do not have anything running on the required ports (3000 for client, 4000 for server, 27017 for mongo.)
 
 ## Running the project


### PR DESCRIPTION
- Clarified the versions being installed for each OS
- Added link for Linux installs
- Removed reference to Kitematic since it's probably just adding confusion here since we don't include instructions on what it does or how to use it. It also isn't relevant to Linux users and is considered a legacy solution.

closes #60 